### PR TITLE
chore: lint all `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ CONTRIBUTORS file.
 
 ### Changelog
 
-### 3.0
+#### 3.0
 
 *   update urllib3 in Pipfile.lock to fix vulnerability bug.
 
-### 2.9
+#### 2.9
 
 *   minor readme changes
 
@@ -98,7 +98,3 @@ CONTRIBUTORS file.
 ### License
 
 This module is licensed under the MIT license. See LICENSE file for more details.
-
-### Author
-
-*   Momozor [skelic3@gmail.com](mailto:skelic3@gmail.com)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ vis = video.search(q='cats', lang='fr',
 print(vis)
 ```
 
-### How do I use it?
+### Usage
 
 I wrote a few _how to_ articles in the [project wiki](https://github.com/momozor/python-pixabay/wiki). Feel free to add more examples or scenarios to the wiki.
 
@@ -79,7 +79,6 @@ CONTRIBUTORS file.
 
 *   minor readme changes
 
-
 #### 2.8
 
 *   minor doc changes
@@ -102,4 +101,4 @@ This module is licensed under the MIT license. See LICENSE file for more details
 
 ### Author
 
-*   Momozor <skelic3@gmail.com>
+*   Momozor [skelic3@gmail.com](mailto:skelic3@gmail.com)


### PR DESCRIPTION
Lint all warning from `codacy`.

I am not sure this pull request is a good idea, You can use `Momozor <skelic3@gmail.com>` but your rule (default codacy's rule) mark it warning.

I see `v2.8`, `v2.7` and `v2.6` have `####` instead of `###` same `v2.9`.

You are deliberately or this is a mistake?